### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,9 @@ on:
       - dev
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/m-xim/textcompose/security/code-scanning/1](https://github.com/m-xim/textcompose/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Based on the steps in the workflow, the only required permission is `contents: read`, which allows the workflow to read the repository contents (e.g., to check out the code). No write permissions are necessary, as the workflow does not modify repository contents or interact with other GitHub features.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
